### PR TITLE
fix: correct boolean operator precedence in MAC address detection

### DIFF
--- a/tools/helper.py
+++ b/tools/helper.py
@@ -75,7 +75,7 @@ def getNetworkInfo(msg):
         raise "Could not find an ethernet interface that can be used as local server (only eth0 and eth1 is supported)"
     logger.info(eth_int)
     
-    if 'net0' or 'en0' in netifaces.interfaces() :
+    if 'net0' in netifaces.interfaces() or 'en0' in netifaces.interfaces():
         if (netifaces.AF_LINK in eth_int):
             msg['mac'] = eth_int[netifaces.AF_LINK][0]["addr"]
     else:


### PR DESCRIPTION
fix: correct boolean operator precedence in MAC address detection

I ran into a bug where the emulator wasn't picking up MAC addresses on my Linux setup (unit info was just showing `NA`).

## File + Function

* **File:** `apis-emulator/tools/helper.py`
* **Function:** `getNetworkInfo()`
* **Line numbers:** 78–83

## The Bug

We had this logic error:

```python
if 'net0' or 'en0' in netifaces.interfaces():
```

Because `'net0'` is a non-empty string, Python evaluates this as `True` immediately. This meant the code *always* executed the macOS path (`AF_LINK`), making the Linux path (`AF_PACKET`) unreachable code.

## Why This Matters

* **Linux Users:** The emulator fails to detect the MAC address silently.
* **CI/CD:** Fresh clones on Ubuntu/CentOS runners were failing to identify network hardware.

## The Fix

I updated the condition to explicitly check membership for both interfaces:

```python
if 'net0' in netifaces.interfaces() or 'en0' in netifaces.interfaces():
```

## Verification

I verified this locally on a Linux machine.

1. **Before:** `curl` returned `NA` for the MAC.
2. **After:** It correctly returns the address (e.g., `aa:bb:cc...`).