### PR TITLE
Feature/python 3.13 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 wheel==0.30.0
-bottle==0.12.18
+bottle>=0.13
 netifaces==0.10.9
-numpy==1.19.4
-requests==2.24.0
+numpy
+requests

--- a/tools/helper.py
+++ b/tools/helper.py
@@ -75,7 +75,7 @@ def getNetworkInfo(msg):
         raise "Could not find an ethernet interface that can be used as local server (only eth0 and eth1 is supported)"
     logger.info(eth_int)
     
-    if 'net0' in netifaces.interfaces() or 'en0' in netifaces.interfaces() :
+    if 'net0' or 'en0' in netifaces.interfaces() :
         if (netifaces.AF_LINK in eth_int):
             msg['mac'] = eth_int[netifaces.AF_LINK][0]["addr"]
     else:

--- a/tools/helper.py
+++ b/tools/helper.py
@@ -75,7 +75,7 @@ def getNetworkInfo(msg):
         raise "Could not find an ethernet interface that can be used as local server (only eth0 and eth1 is supported)"
     logger.info(eth_int)
     
-    if 'net0' or 'en0' in netifaces.interfaces() :
+    if 'net0' in netifaces.interfaces() or 'en0' in netifaces.interfaces() :
         if (netifaces.AF_LINK in eth_int):
             msg['mac'] = eth_int[netifaces.AF_LINK][0]["addr"]
     else:

--- a/venv.sh
+++ b/venv.sh
@@ -9,5 +9,5 @@ fi
 
 $PYTHON -m venv venv
 . venv/bin/activate
-pip install --upgrade pip
-pip install -r requirements.txt
+pip install --upgrade pip setuptools wheel
+pip install --no-build-isolation -r requirements.txt


### PR DESCRIPTION
This PR fixes compatibility issues with Python 3.13 in the emulator module.
Changes made:
- Updated venv.sh to install setuptools and wheel, and use --no-build-isolation flag
- Upgraded bottle from 0.12.18 to 0.13 or higher (the cgi module was removed in Python 3.13)
- Removed version constraint on numpy to allow compatible versions with Python 3.13
- Updated requests library to fix urllib3 2.x compatibility issues
- Restored missing helper.py file in the tools directory
The emulator now starts and runs successfully on Python 3.13.
Co-authored-by: YATIN JAMWAL <YATIN072007@users.noreply.github.com>